### PR TITLE
Add Decision trees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ utils/__pycache__/
 *.pyc
 *.npy
 temp
+.vscode/launch.json

--- a/Course1/Week2/feature_scaling_and_learning_rate.py
+++ b/Course1/Week2/feature_scaling_and_learning_rate.py
@@ -1,5 +1,5 @@
 from rawsight import least_squares_cost_function, MaxNorm, MeanNorm, ZScoreNorm
-from datasets import load_housing_data, Dataset
+from rawsight.datasets import load_housing_data, Dataset
 from .multiple_linear_regression import run
 
 

--- a/Course1/Week2/multiple_linear_regression.py
+++ b/Course1/Week2/multiple_linear_regression.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 from rawsight import least_squares_cost_function
-from datasets import Dataset
+from rawsight.datasets import Dataset
 from rawsight.models import LinearModel
 from rawsight.optimizers import batch_gradient_descent
 

--- a/Course1/Week2/sklearn_linear_regression.py
+++ b/Course1/Week2/sklearn_linear_regression.py
@@ -1,5 +1,5 @@
 import numpy as np
-from datasets import Dataset, load_housing_data
+from rawsight.datasets import Dataset, load_housing_data
 from rawsight import ZScoreNorm
 from sklearn.preprocessing import StandardScaler
 from sklearn.linear_model import SGDRegressor

--- a/Course2/Week1/coffee_roasting_numpy.py
+++ b/Course2/Week1/coffee_roasting_numpy.py
@@ -1,7 +1,7 @@
 import tensorflow as tf
 from numpy.typing import ArrayLike
 
-from datasets import load_coffee_data
+from rawsight.datasets import load_coffee_data
 import numpy as np
 from rawsight.nn.layers import DenseLayer
 

--- a/Course2/Week1/coffee_roasting_tensorflow.py
+++ b/Course2/Week1/coffee_roasting_tensorflow.py
@@ -1,5 +1,5 @@
 import tensorflow as tf
-from datasets import load_coffee_data
+from rawsight.datasets import load_coffee_data
 import numpy as np
 
 data = load_coffee_data()

--- a/Course2/Week1/neurons_and_layers.py
+++ b/Course2/Week1/neurons_and_layers.py
@@ -3,7 +3,7 @@ Showing the Linear and Logistic Dense layers are just Regression and that
 we have parity with tensorflow for my implementation of Linear and Logistic Regression.
 """
 import tensorflow as tf
-from datasets import load_tumor_simple
+from rawsight.datasets import load_tumor_simple
 from rawsight.regression import LinearRegression, LogisticRegression
 
 

--- a/Course2/Week3/applying_ml.py
+++ b/Course2/Week3/applying_ml.py
@@ -1,4 +1,4 @@
-from datasets import load_course2_week3_data
+from rawsight.datasets import load_course2_week3_data
 
 dataset = load_course2_week3_data()
 print(dataset.X_train.shape)

--- a/rawsight/__init__.py
+++ b/rawsight/__init__.py
@@ -3,7 +3,12 @@ from rawsight.cost_functions import (
     least_squares_cost_function,
     logistic_cost_function,
 )
-from rawsight.models import LinearModel, Model, LogisticModel, add_poly_features
+from rawsight.models import LinearModel, LogisticModel, Model, add_poly_features
+
+from . import datasets as datasets
+from . import models as models
+from . import tests as tests
+from . import trees as trees
 from .input_validation import get_n_features, transpose
+from .normalization import MaxNorm, MeanNorm, NormalizerProtocol, ZScoreNorm
 from .optimizers import batch_gradient_descent, regularized_batch_gradient_descent
-from .normalization import NormalizerProtocol, ZScoreNorm, MaxNorm, MeanNorm

--- a/rawsight/cost_functions/cost_function_factory.py
+++ b/rawsight/cost_functions/cost_function_factory.py
@@ -9,7 +9,7 @@ from rawsight.models import Model
 
 from .regularization import Regularization
 
-NDArrayInt = np.ndarray[Any, np.dtype[int]]
+NDArrayInt = np.ndarray[Any, np.dtype[np.int_]]
 _CostFunctionCallable = (
     Callable[[ArrayLike, ArrayLike], float] | Callable[[ArrayLike, NDArrayInt], float]
 )

--- a/rawsight/cost_functions/cost_functions.py
+++ b/rawsight/cost_functions/cost_functions.py
@@ -3,6 +3,7 @@ from typing import Any
 import numpy as np
 from numpy import ScalarType
 from numpy.typing import ArrayLike, NDArray
+
 from .cost_function_factory import CostFunction, NDArrayInt
 from .regularization import SquaredSumRegularization
 
@@ -48,6 +49,24 @@ def _cross_entropy_cost_gradient(fy: NDArray, y: NDArrayInt) -> ArrayLike:
 def categorial_cost(fy: NDArray, y: NDArrayInt) -> float:
     """Simply the fraction of incorrect predictions."""
     return np.sum(y != fy) / len(y)
+
+
+def binary_entropy(p1: float) -> float:
+    """Entropy of p1, fraction of positive examples."""
+    return -p1 * np.log2(p1) - (1 - p1) * np.log2(1 - p1)
+
+
+def binary_entropy_cost(y: NDArrayInt, positive: int = 1) -> float:
+    """binary Entropy cost based on positive examples."""
+    if len(y) == 0:
+        return 0
+
+    p1 = np.sum(y == positive) / len(y)
+
+    if p1 == 0 or p1 == 1:
+        return 0
+
+    return binary_entropy(p1)
 
 
 # def _cross_entropy_loss(fy: NDArray, y: NDArrayInt) -> NDArray:

--- a/rawsight/tests/test_binary_tree.py
+++ b/rawsight/tests/test_binary_tree.py
@@ -1,0 +1,66 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from rawsight.trees import (
+    ChildNodes,
+    Tree,
+    TreeIndices,
+    TreeNode,
+    binary_split,
+    build_binary_tree,
+)
+from rawsight.trees._splitter_protocol import Splitter
+from rawsight.trees.binary_tree import binary_info_gain
+from rawsight.trees.infogain import BaseInfoGain, InfoGain, InfoGainType
+
+X_train = np.array(
+    [
+        [1, 1, 1],
+        [1, 0, 1],
+        [1, 0, 0],
+        [1, 0, 0],
+        [1, 1, 1],
+        [0, 1, 1],
+        [0, 0, 0],
+        [1, 0, 1],
+        [0, 1, 0],
+        [1, 0, 0],
+    ]
+)
+y_train = np.array([1, 1, 0, 0, 1, 0, 0, 1, 1, 0])
+ref_tree: Tree = [
+    (([0, 1, 4, 5, 7], [2, 3, 6, 8, 9]), 2, 0.2780719051126377),
+    (([0, 1, 4, 7], [5]), 0, 0.7219280948873623),
+    (([8], [2, 3, 6, 9]), 1, 0.7219280948873623),
+]
+
+
+def test_info_gain_factory():
+    binsplit = binary_info_gain.splitter(X_train, list(range(len(X_train))), 1)
+    assert binsplit == ([0, 4, 5, 8], [1, 2, 3, 6, 7, 9])
+    infogained = binary_info_gain.info_gainer(
+        y_train, (y_train[binsplit[0]], y_train[binsplit[1]])
+    )
+
+    pytest.approx(infogained, 0.12451124978365313)
+    assert isinstance(binary_info_gain, InfoGain)
+    # print(type())
+    assert binary_info_gain.__class__.__name__ == "BinaryInfoGain"
+
+
+def test_binary_tree():
+    bintree: Tree = build_binary_tree(
+        X_train, y_train, max_depth=2, min_info_gain=0.001
+    )
+
+    for i, node in enumerate(bintree):
+        childnodes = node[0]
+        assert childnodes == ref_tree[i][0]
+
+        assert node[1] == ref_tree[i][1]
+
+        pytest.approx(node[2], ref_tree[i][2], abs=1e-3)
+
+    print(bintree)
+    print(ref_tree)

--- a/rawsight/tests/test_linear_regression.py
+++ b/rawsight/tests/test_linear_regression.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from datasets import load_housing_data, Dataset
+from rawsight.datasets import load_housing_data, Dataset
 from typing import Callable
 from sklearn.linear_model import SGDRegressor
 from rawsight.cost_functions import least_squares_cost_function
@@ -94,7 +94,7 @@ def test_regularized_better(
 
 def test_parity_to_tensorflow():
     import tensorflow as tf
-    from datasets import load_tumor_simple
+    from rawsight.datasets import load_tumor_simple
     from rawsight.regression import LinearRegression
 
     dataset = load_tumor_simple()

--- a/rawsight/tests/test_logistic_regression.py
+++ b/rawsight/tests/test_logistic_regression.py
@@ -134,7 +134,7 @@ def test_logistic_regression_against_sklearn(regularized_logistic_regression):
 
 def test_logistic_regression_against_tensorflow():
     import tensorflow as tf
-    from datasets import load_tumor_simple
+    from rawsight.datasets import load_tumor_simple
     from rawsight.regression import LogisticRegression
 
     dataset = load_tumor_simple()

--- a/rawsight/tests/test_normalization.py
+++ b/rawsight/tests/test_normalization.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy as np
-from datasets import load_housing_data
+from rawsight.datasets import load_housing_data
 from rawsight import ZScoreNorm, MaxNorm, MeanNorm
 from sklearn.preprocessing import StandardScaler
 

--- a/rawsight/trees/__init__.py
+++ b/rawsight/trees/__init__.py
@@ -1,0 +1,13 @@
+"""tree based algorithms, splitting, info gain, entropy, ensemble trees, random forest, XGBoost, tree Regression, etc."""
+from .binary_tree import build_binary_tree
+from .splitting import binary_split
+from .tree import ChildNodes, Tree, TreeIndices, TreeNode
+
+__all__ = [
+    "build_binary_tree",
+    "Tree",
+    "TreeNode",
+    "TreeIndices",
+    "ChildNodes",
+    "binary_split",
+]

--- a/rawsight/trees/_splitter_protocol.py
+++ b/rawsight/trees/_splitter_protocol.py
@@ -1,0 +1,12 @@
+from typing import Any, Protocol
+
+import numpy as np
+
+from .tree import ChildNodes, TreeIndices
+
+
+class Splitter(Protocol):
+    def __call__(
+        self, data: np.ndarray, node_indices: TreeIndices, feature: int, **kwargs: Any
+    ) -> ChildNodes:
+        ...

--- a/rawsight/trees/binary_tree.py
+++ b/rawsight/trees/binary_tree.py
@@ -1,0 +1,95 @@
+from typing import Any
+
+import numpy as np
+
+from ..cost_functions import NDArrayInt, binary_entropy_cost
+from .infogain import InfoGain, info_gain_factory
+from .splitting import binary_split
+from .tree import Tree, TreeIndices
+from .tree_builder import BuildPars, TreeBuilder
+
+# def _binary_split(
+#     data: np.ndarray, node_indices: TreeIndices, feature: int, **kwargs: Any
+# ) -> tuple[TreeIndices, TreeIndices]:
+#     """
+#     Splits the data at the given node into
+#     positive and negative branches
+
+#     Args:
+#         X (ndarray):             Data matrix of shape(n_samples, n_features)
+#         node_indices (list):     List containing the active indices. I.e, the samples being considered at this step.
+#         feature (int):           Index of feature to split on
+
+#     Returns:
+#         post_idx (list):     Indices with feature value == 1
+#         neg_idx (list):    Indices with feature value == 0
+#     """
+#     if len(node_indices) == 0:
+#         return [], []
+
+#     rows = data[node_indices]
+#     col = rows[:, feature]
+
+#     pos = np.argwhere(col == 1).flatten()
+#     neg = np.argwhere(col == 0).flatten()
+
+#     pos_idx: TreeIndices = []
+#     neg_idx: TreeIndices = []
+
+#     if len(neg) > 0:
+#         neg_idx = neg.tolist()
+#     if len(pos) > 0:
+#         pos_idx = pos.tolist()
+
+#     pos_idx = np.array(node_indices)[pos_idx].tolist()
+#     neg_idx = np.array(node_indices)[neg_idx].tolist()
+
+#     return pos_idx, neg_idx
+
+
+def _calc_binary_info_weights(
+    y_node: NDArrayInt | TreeIndices, y_part: NDArrayInt | TreeIndices
+) -> float:
+    n_node = len(y_node)
+    n_part = len(y_part)
+    if n_node == 0 or n_part == 0:
+        return 0.0
+    w_part = n_part / n_node
+    return w_part
+
+
+def _binary_info_gain(
+    y_node: NDArrayInt, y_left: NDArrayInt, y_right: NDArrayInt
+) -> float:
+    w_left = _calc_binary_info_weights(y_node, y_left)
+    w_right = _calc_binary_info_weights(y_node, y_right)
+
+    h_root = binary_entropy_cost(y_node)
+    h_left, h_right = binary_entropy_cost(y_left), binary_entropy_cost(y_right)
+
+    info_gain = h_root - (w_left * h_left + w_right * h_right)
+    return info_gain
+
+
+def calc_binary_info_gain(y_node: NDArrayInt, leafs: tuple[NDArrayInt, ...]) -> float:
+    return _binary_info_gain(y_node, leafs[0], leafs[1])
+
+
+binary_info_gain: InfoGain = info_gain_factory(
+    "BinaryInfoGain", binary_split, calc_binary_info_gain
+)
+
+
+binary_tree_builder = TreeBuilder(binary_info_gain, pars=BuildPars())
+
+
+def build_binary_tree(
+    data: np.ndarray,
+    y: NDArrayInt,
+    max_depth: int = 2,
+    min_info_gain: float = 0.02,
+    **kwargs: Any
+) -> Tree:
+    binary_tree_builder.pars.max_depth = max_depth
+    binary_tree_builder.pars.min_info_gain = min_info_gain
+    return binary_tree_builder(data, y, **kwargs)

--- a/rawsight/trees/infogain.py
+++ b/rawsight/trees/infogain.py
@@ -1,0 +1,33 @@
+import numpy as np
+
+from rawsight.cost_functions import NDArrayInt, binary_entropy_cost
+
+from .splitting import binary_split
+
+
+def _calc_binary_info_weights(
+    y_node: NDArrayInt | list[int], y_part: NDArrayInt | list[int]
+) -> float:
+    w_part = len(y_part) / len(y_node)
+    return w_part
+
+
+def info_gain(y_node: NDArrayInt, y_left: NDArrayInt, y_right: NDArrayInt) -> float:
+    w_left = _calc_binary_info_weights(y_node, y_left)
+    w_right = _calc_binary_info_weights(y_node, y_right)
+
+    h_root = binary_entropy_cost(y_node)
+    h_left, h_right = binary_entropy_cost(y_left), binary_entropy_cost(y_right)
+
+    info_gain = h_root - (w_left * h_left + w_right * h_right)
+    return info_gain
+
+
+def calc_binary_info_gain(
+    data: np.ndarray, y: NDArrayInt, node_indices: list[int], feature: int
+) -> float:
+    pos_indices, neg_indices = binary_split(data, node_indices, feature)
+    y_node = y[node_indices]
+    y_pos = y[pos_indices]
+    y_neg = y[neg_indices]
+    return info_gain(y_node, y_pos, y_neg)

--- a/rawsight/trees/splitting.py
+++ b/rawsight/trees/splitting.py
@@ -1,0 +1,40 @@
+import numpy as np
+
+
+def binary_split(
+    data: np.ndarray, node_indices: list[int], feature: int
+) -> tuple[list[int], list[int]]:
+    """
+    Splits the data at the given node into
+    positive and negative branches
+
+    Args:
+        X (ndarray):             Data matrix of shape(n_samples, n_features)
+        node_indices (list):     List containing the active indices. I.e, the samples being considered at this step.
+        feature (int):           Index of feature to split on
+
+    Returns:
+        post_idx (list):     Indices with feature value == 1
+        neg_idx (list):    Indices with feature value == 0
+    """
+    if len(node_indices) == 0:
+        return [], []
+
+    rows = data[node_indices]
+    col = rows[:, feature]
+
+    pos = np.argwhere(col == 1).flatten()
+    neg = np.argwhere(col == 0).flatten()
+
+    pos_idx: list[int] = []
+    neg_idx: list[int] = []
+
+    if len(neg) > 0:
+        neg_idx = neg.tolist()
+    if len(pos) > 0:
+        pos_idx = pos.tolist()
+
+    pos_idx = np.array(node_indices)[pos_idx].tolist()
+    neg_idx = np.array(node_indices)[neg_idx].tolist()
+
+    return pos_idx, neg_idx

--- a/rawsight/trees/splitting.py
+++ b/rawsight/trees/splitting.py
@@ -1,9 +1,45 @@
+from typing import Any
+
 import numpy as np
+
+from ..cost_functions import NDArrayInt
+from .infogain import InfoGain
+from .tree import TreeIndices
+
+
+def get_best_split(
+    infogain: InfoGain,
+    data: np.ndarray,
+    y: NDArrayInt,
+    node_indices: TreeIndices,
+    **kwargs: Any
+) -> tuple[int, float]:
+    """
+    Finds the best feature to split on and its info gain for the given node
+
+    Args:
+        data (ndarray):             Data matrix of shape(n_samples, n_features)
+        y (ArrayLike):             Target vector of shape(n_samples,)
+        node_indices (list):     List containing the active indices. I.e, the samples being considered at this step.
+
+    Returns:
+        best_feature (int):     Index of the best feature to split on
+        best_info_gain (int):   Information gain from the best split
+    """
+    best_feature = -1
+    best_info_gain = 0
+    for feature in range(data.shape[1]):
+        info_gain = infogain(data, y, node_indices, feature, **kwargs)
+        if info_gain > best_info_gain:
+            best_info_gain = info_gain
+            best_feature = feature
+
+    return best_feature, best_info_gain
 
 
 def binary_split(
-    data: np.ndarray, node_indices: list[int], feature: int
-) -> tuple[list[int], list[int]]:
+    data: np.ndarray, node_indices: TreeIndices, feature: int, **kwargs: Any
+) -> tuple[TreeIndices, TreeIndices]:
     """
     Splits the data at the given node into
     positive and negative branches
@@ -26,8 +62,8 @@ def binary_split(
     pos = np.argwhere(col == 1).flatten()
     neg = np.argwhere(col == 0).flatten()
 
-    pos_idx: list[int] = []
-    neg_idx: list[int] = []
+    pos_idx: TreeIndices = []
+    neg_idx: TreeIndices = []
 
     if len(neg) > 0:
         neg_idx = neg.tolist()

--- a/rawsight/trees/tree.py
+++ b/rawsight/trees/tree.py
@@ -1,0 +1,10 @@
+from typing import TypeAlias
+
+TreeIndices: TypeAlias = list[int]  # Indices of the samples in the node.
+ChildNodes: TypeAlias = tuple[
+    TreeIndices, ...
+]  # Indices of the samples in the N child nodes
+TreeNode: TypeAlias = tuple[
+    ChildNodes, int, float
+]  # ChildNode branches, feature index, and information gain.
+Tree: TypeAlias = list[TreeNode]  # list of TreeNodes.

--- a/rawsight/trees/tree_builder.py
+++ b/rawsight/trees/tree_builder.py
@@ -1,0 +1,104 @@
+from dataclasses import dataclass
+from typing import Any, Optional, TypeGuard
+
+import numpy as np
+
+from ..cost_functions import NDArrayInt
+from .infogain import InfoGain
+from .splitting import get_best_split
+from .tree import ChildNodes, Tree, TreeIndices, TreeNode
+
+
+@dataclass
+class BuildPars:
+    branches: int = 0
+    max_depth: int = 2
+    current_depth: int = 0  # equivalent to starting depth before use.
+    min_info_gain: float = (
+        0.02  # if info gain is less than min_info_gain, then we don't split.
+    )
+
+    def dive(self, new_depth: int) -> None:
+        if self.current_depth < new_depth:
+            self.current_depth = new_depth
+
+    def branch(self, new_branches: int) -> None:
+        self.branches += new_branches
+
+
+class TreeBuilder:
+    def __init__(
+        self,
+        infogain: InfoGain,
+        input_tree: Optional[Tree] = None,
+        pars: BuildPars = BuildPars(),
+    ) -> None:
+        if input_tree is None:
+            input_tree = []
+        self.tree = input_tree
+        self.pars = pars
+        self.infogain = infogain
+
+    def build_child_nodes(
+        self,
+        data: np.ndarray,
+        y: NDArrayInt,
+        node_indices: TreeIndices,
+        current_depth: int = 0,
+        **kwargs: Any
+    ) -> None:
+        # Stop if we have reached the maximum depth.
+        if current_depth >= self.pars.max_depth:
+            return
+
+        # Pick best feature and split node into N leafs.
+        leafs, feature, info_gain = self.split(data, y, node_indices, **kwargs)
+        self.tree.append((leafs, feature, info_gain))
+
+        # These should be moved to a Tree class:
+        self.pars.branch(len(leafs))
+        self.pars.dive(current_depth)
+
+        # Stop if we have reached the minimum information gain.
+        if info_gain < self.pars.min_info_gain:
+            return
+
+        # Recursively build child nodes.
+        for node in leafs:
+            self.build_child_nodes(
+                data, y, node, current_depth=current_depth + 1, **kwargs
+            )
+
+    def build_recursive(
+        self,
+        data: np.ndarray,
+        y: NDArrayInt,
+        node_indices: Optional[TreeIndices] = None,
+        **kwargs: Any
+    ) -> None:
+        """Build a tree recursively starting from pars.current_depth."""
+        if node_indices is None:
+            node_indices = list(range(len(y)))
+
+        self.build_child_nodes(data, y, node_indices, self.pars.current_depth, **kwargs)
+
+    def split(
+        self, data: np.ndarray, y: NDArrayInt, node_indices: TreeIndices, **kwargs: Any
+    ) -> TreeNode:
+        best_feature, best_info_gain = get_best_split(
+            self.infogain, data, y, node_indices
+        )
+        leafs: ChildNodes = self.infogain.splitter(
+            data, node_indices, best_feature, **kwargs
+        )
+        return leafs, best_feature, best_info_gain
+
+    def __call__(
+        self,
+        data: np.ndarray,
+        y: NDArrayInt,
+        node_indices: Optional[TreeIndices] = None,
+        **kwargs: Any
+    ) -> Tree:
+        self.build_recursive(data, y, node_indices, **kwargs)
+        return self.tree


### PR DESCRIPTION
This adds decision trees as the trees module.


1. Adds trees module containing decision trees.
2. There is a prebuilt `build_binary_tree` and a test matching the case from the lab.
3. Adds TreeBuilder class, which can recursively build a decision tree given an `InfoGain`  (see below) and `BuildPars`. BuildPars are parameters to control the building of a tree such as  max_depth, current_depth, min_info_gain, and the number of branches.
4. Adds some unit tests for decision trees.
5. Adds `Splitter` Protocol class for all types of splitter logic, implements binary_split.
6. Adds `InfoGainType` and `InfoGain` Protocol classes, implements binary entropy cost info gain.
7.  Adds InfoGain factory that allows for N-split decision trees, not just binary, as long as the corresponding InfoGainType and Splitter are created. Currently we have only implemented binary but the abstractions works for N-split, such as QuadTrees.
8. Adds `get_best_split` which takes an InfoGain instance and calculates the highest information gain split (for the input tree data and active nodes).
9. Adds TypeAlias's for Tree, ChildNodes, TreeNode, and TreeIndices. 
10. Also fixes some test configs for the new package architecture since it was broken, and ensures all tests are passing.

